### PR TITLE
Allow mentors to assign submissions to themselves

### DIFF
--- a/lib/models/submission.js
+++ b/lib/models/submission.js
@@ -36,6 +36,10 @@ var submissionSchema = new mongoose.Schema({
   flagged: {type: Boolean, default: false},
   onChangeUrl: {type: String, validate: safeUrl},
   creationDate: {type: Date, default: Date.now},
+  assignedTo: {
+    mentor: {type: String, validate: validEmail},
+    expiry: Date
+  },
   // TODO: Ensure that at least one rubric is required.
   rubric: {
     items: [
@@ -79,6 +83,37 @@ reviewSchema.pre('save', function(next) {
     next(err);
   });
 });
+
+// Atomically assign the given mentor w/ the given expiry time to the
+// submission.
+//
+// Calls cb with (err, submission). If the submission is already assigned
+// to someone, submission will be null.
+//
+// The document this method is called on becomes invalidated immediately
+// after use; if you need to keep doing things with it, use the submission
+// object passed to the callback.
+submissionSchema.methods.assignTo = function(email, expiry, cb) {
+  var criteria = {_id: this._id};
+  if (this.assignedTo.mentor != email &&
+      this.assignedTo.expiry &&
+      this.assignedTo.expiry.getTime() > Date.now())
+    return cb(null, null);
+  if (this.assignedTo.mentor)
+    criteria.assignedTo = {
+      mentor: this.assignedTo.mentor,
+      expiry: this.assignedTo.expiry
+    };
+  Submission.findOneAndUpdate(criteria, {
+    assignedTo: {
+      mentor: email,
+      expiry: expiry
+    }
+  }, function(err, submission) {
+    if (err) return cb(err);
+    cb(null, submission);
+  });
+};
 
 submissionSchema.methods.latestReview = function() {
   return this.reviews[this.reviews.length-1];

--- a/lib/models/submission.js
+++ b/lib/models/submission.js
@@ -115,6 +115,14 @@ submissionSchema.methods.assignTo = function(email, expiry, cb) {
   });
 };
 
+submissionSchema.methods.getAssignee = function() {
+  if (!this.assignedTo.expiry ||
+      this.assignedTo.expiry.getTime() <= Date.now())
+    return null;
+
+  return this.assignedTo.mentor;
+};
+
 submissionSchema.methods.latestReview = function() {
   return this.reviews[this.reviews.length-1];
 };

--- a/lib/website.js
+++ b/lib/website.js
@@ -5,6 +5,7 @@ var demoData = require('../test/data');
 var docs = require('./documentation');
 
 const RESULTS_PER_PAGE = 10;
+const ASSIGNMENT_LOCKOUT_MS = exports.ASSIGNMENT_LOCKOUT_MS = 1000 * 60 * 15;
 
 function callWebhook(submission) {
   if (submission.onChangeUrl) {
@@ -53,6 +54,27 @@ exports.submissionDetail = function(req, res, next) {
   res.render('submission-detail.html');
 };
 
+function assignAssessment(req, res, next) {
+  var exp = Date.now() + ASSIGNMENT_LOCKOUT_MS;
+  res.locals.submission.assignTo(req.session.email, exp, function(err, sub) {
+    if (err) return next(err);
+    if (sub) {
+      return res.redirect(303, req.path + '#assess');
+    } else {
+      req.flash('error', 'Sorry, someone else is already assessing this.');
+      return res.redirect(303, req.path);
+    }
+  });
+}
+
+function unassignAssessment(req, res, next) {
+  var exp = Date.now();
+  res.locals.submission.assignTo(req.session.email, exp, function(err, sub) {
+    if (err) return next(err);
+    return res.redirect(303, req.path);
+  });
+}
+
 exports.submitAssessment = function(req, res, next) {
   function respond(flashType, flashMsg) {
     return function(err) {
@@ -65,6 +87,12 @@ exports.submitAssessment = function(req, res, next) {
 
   var submission = res.locals.submission;
   var satisfiedRubrics = [];
+
+  if (req.body['action'] == 'assign')
+    return assignAssessment(req, res, next);
+
+  if (req.body['action'] == 'unassign')
+    return unassignAssessment(req, res, next);
 
   if (req.body['action'] == 'flag') {
     return Submission.update({

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -40,5 +40,8 @@ window.reloadPage = function() {
   $(".js-logout").tooltip();
 
   // Miscellaneous stuff that every page might need.
-  if ($.fn.timeago) $("time.timeago").timeago();
+  if ($.fn.timeago) {
+    $.timeago.settings.allowFuture = true;
+    $("time.timeago").timeago();
+  }
 })();

--- a/test/submission-model.test.js
+++ b/test/submission-model.test.js
@@ -263,6 +263,7 @@ describe('Submission', function() {
     var fakeTime = 0;
     var oldS;
 
+    should.equal(submission.getAssignee(), null);
     sinon.stub(Date, 'now', function() { return fakeTime; });
     async.waterfall([
       submission.save.bind(submission),
@@ -270,11 +271,13 @@ describe('Submission', function() {
       function assignmentSucceeds(s, cb) {
         s.assignedTo.mentor.should.eql("mentor@mentors.org");
         s.assignedTo.expiry.getTime().should.eql(5);
+        should.equal(s.getAssignee(), "mentor@mentors.org");
         oldS = s;
         cb(null, s);
       },
       function assignDuringUnexpiredAssignmentFails(s, cb) {
         fakeTime = 1;
+        should.equal(s.getAssignee(), "mentor@mentors.org");
         s.assignTo("other@mentors.org", 5, function(err, nullSub) {
           if (err) return cb(err);
           cb(nullSub === null ? null : new Error("nullSub !== null"), s);
@@ -282,8 +285,10 @@ describe('Submission', function() {
       },
       function assignAfterExpiredAssignmentSucceeds(s, cb) {
         fakeTime = 6;
+        should.equal(s.getAssignee(), null);
         s.assignTo("other2@mentors.org", 10, function(err, s) {
           if (err) return cb(err);
+          should.equal(s.getAssignee(), "other2@mentors.org");
           cb(s === null ? new Error("s is null") : null);
         });
       },

--- a/test/submission-model.test.js
+++ b/test/submission-model.test.js
@@ -215,4 +215,89 @@ describe('Submission', function() {
     s.isLearnerUnderage().should.eql(false);
     s.save(done);
   });
+
+  // This test only really verifies how we expect Mongoose to work, not any
+  // special trait of our code.
+  it('should have expected mongoose update semantics', function(done) {
+    var s = new Submission(data.submissions['base']);
+
+    s.save(function(err) {
+      if (err) throw err;
+
+      Submission.findOne({_id: s._id}, function(err, s2) {
+        if (err) throw err;
+        if (!s2) throw new Error("s2 should be truthy");
+
+        s.assignedTo.mentor = "a@lol.org";
+        s.learner = "learner@somewhere.org";
+        s.save(function(err, newS) {
+          if (err) throw err;
+          if (newS !== s) throw new Error("newS !== s");
+          s.assignedTo.mentor.should.eql("a@lol.org");
+          if (s2.assignedTo.mentor) throw new Error();
+
+          // Even though s2 now represents an "old" version of our model,
+          // changing it and saving it shouldn't raise any errors.
+          s2.assignedTo.mentor = "b@lol.org";
+          s2.learner.should.eql("brian@example.org");
+          s2.save(function(err) {
+            if (err) throw err;
+            s.assignedTo.mentor.should.eql("a@lol.org");
+            s2.assignedTo.mentor.should.eql("b@lol.org");
+            Submission.findOne({_id: s._id}, function(err, s3) {
+              s3.assignedTo.mentor.should.eql("b@lol.org");
+
+              // Even though s2's learner value was brian@example.org,
+              // it shouldn't have been saved because we didn't change it.
+              s3.learner.should.eql("learner@somewhere.org");
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('should assign submissions to mentors atomically', function(done) {
+    var submission = new Submission(data.submissions['base']);
+    var fakeTime = 0;
+    var oldS;
+
+    sinon.stub(Date, 'now', function() { return fakeTime; });
+    async.waterfall([
+      submission.save.bind(submission),
+      function(s, _, cb) { s.assignTo("mentor@mentors.org", 5, cb); },
+      function assignmentSucceeds(s, cb) {
+        s.assignedTo.mentor.should.eql("mentor@mentors.org");
+        s.assignedTo.expiry.getTime().should.eql(5);
+        oldS = s;
+        cb(null, s);
+      },
+      function assignDuringUnexpiredAssignmentFails(s, cb) {
+        fakeTime = 1;
+        s.assignTo("other@mentors.org", 5, function(err, nullSub) {
+          if (err) return cb(err);
+          cb(nullSub === null ? null : new Error("nullSub !== null"), s);
+        });
+      },
+      function assignAfterExpiredAssignmentSucceeds(s, cb) {
+        fakeTime = 6;
+        s.assignTo("other2@mentors.org", 10, function(err, s) {
+          if (err) return cb(err);
+          cb(s === null ? new Error("s is null") : null);
+        });
+      },
+      function staleAssignmentsShouldFail(cb) {
+        oldS.assignedTo.mentor.should.eql("mentor@mentors.org");
+        oldS.assignedTo.expiry.getTime().should.eql(5);
+        oldS.assignTo("other2@mentors.org", 10, function(err, nullSub) {
+          if (err) return cb(err);
+          cb(nullSub === null ? null : new Error("stale assignment fail"));
+        });
+      }
+    ], function(err) {
+      Date.now.restore();
+      done(err);
+    });
+  });
 });

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -84,7 +84,9 @@ describe('views/', function() {
     it('should show review form for unreviewed submissions', function() {
       var $ = renderAssignedSubmission(data.submissions['base']);
       $('button[value="assess"]').length.should.eql(1);
+      $('button[value="unassign"]').length.should.eql(1);
       $('button[value="unflag"]').length.should.eql(0);
+      $('button[value="assign"]').length.should.eql(0);
     });
 
     it('should show unflag button for flagged submissions', function() {
@@ -113,6 +115,29 @@ describe('views/', function() {
         evidence: [{url: 'http://z/', mediaType: 'link'}]
       }));
       $('.thumbnail a').text().trim().should.eql('http://z/');
+    });
+
+    it('should show begin assessment button', function() {
+      var s = new models.Submission(data.reviewedSubmissions['base']);
+      var $ = render('submission-detail.html', {
+        submission: s,
+        email: 'a@b.org'
+      });
+      $('button[value="assign"]').length.should.eql(1);
+      $('button[value="assess"]').length.should.eql(0);
+    });
+
+    it('should show assignment info when not assignee', function() {
+      var s = new models.Submission(data.reviewedSubmissions['base']);
+      s.assignedTo.mentor = 'foo@bar.org';
+      s.assignedTo.expiry = Date.now() + 1000000;
+      var $ = render('submission-detail.html', {
+        submission: s,
+        email: 'a@b.org'
+      });
+      $('button[value="assign"]').length.should.eql(0);
+      $('button[value="assess"]').length.should.eql(0);
+      $.html().should.match(/foo@bar\.org/);
     });
   });
 

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -59,23 +59,30 @@ describe('views/', function() {
   });
 
   describe('submission-detail.html', function() {
+    function renderAssignedSubmission(props) {
+      var s = new models.Submission(props);
+      s.assignedTo.mentor = 'foo@bar.org';
+      s.assignedTo.expiry = Date.now() + 1000000;
+      return render('submission-detail.html', {
+        submission: s,
+        email: 'foo@bar.org'
+      });
+    }
+
     it('should hide email of underage learners', function() {
-      var s = new models.Submission(data.submissions['canned-responses']);
-      var $ = render('submission-detail.html', {submission: s});
+      var $ = renderAssignedSubmission(data.submissions['canned-responses']);
       $.html().should.match(/An underage learner/i);
       $.html().should.not.match(/brian@example\.org/);
     });
 
     it('should show email of non-underage learners', function() {
-      var s = new models.Submission(data.submissions['base']);
-      var $ = render('submission-detail.html', {submission: s});
+      var $ = renderAssignedSubmission(data.submissions['base']);
       $.html().should.not.match(/An underage learner/i);
       $.html().should.match(/brian@example\.org/);
     });
 
     it('should show review form for unreviewed submissions', function() {
-      var s = new models.Submission(data.submissions['base']);
-      var $ = render('submission-detail.html', {submission: s});
+      var $ = renderAssignedSubmission(data.submissions['base']);
       $('button[value="assess"]').length.should.eql(1);
       $('button[value="unflag"]').length.should.eql(0);
     });
@@ -95,18 +102,16 @@ describe('views/', function() {
     });
 
     it('should embed image evidence in page', function() {
-      var s = new models.Submission(data.baseSubmission({
+      var $ = renderAssignedSubmission(data.baseSubmission({
         evidence: [{url: 'http://u/', mediaType: 'image'}]
       }));
-      var $ = render('submission-detail.html', {submission: s});
       $('.thumbnail img').attr("src").should.eql('http://u/');
     });
 
     it('should hyperlink to link evidence', function() {
-      var s = new models.Submission(data.baseSubmission({
+      var $ = renderAssignedSubmission(data.baseSubmission({
         evidence: [{url: 'http://z/', mediaType: 'link'}]
       }));
-      var $ = render('submission-detail.html', {submission: s});
       $('.thumbnail a').text().trim().should.eql('http://z/');
     });
   });

--- a/test/website.test.js
+++ b/test/website.test.js
@@ -222,6 +222,8 @@ describe('Website', function() {
   });
 
   describe('POST /submissions/:submissionId', function() {
+    this.timeout(15000);
+
     beforeEach(setupFixtures);
 
     it('should not crash when calling onChangeUrl webhook', function(done) {

--- a/test/website.test.js
+++ b/test/website.test.js
@@ -321,6 +321,96 @@ describe('Website', function() {
       ], done);
     });
 
+    it('should allow self-assigning', function(done) {
+      loggedInEmail = "a@b.com";
+      async.series([
+        function(cb) {
+          request(app)
+            .post('/submissions/a07f1f77bcf86cd7994390ff')
+            .send({
+              _csrf: 'deadbeef',
+              action: 'assign'
+            })
+            .expect('Location', '/submissions/a07f1f77bcf86cd7994390ff#assess')
+            .expect(303, cb);
+        },
+        function(cb) {
+          models.Submission.findOne({
+            _id: 'a07f1f77bcf86cd7994390ff'
+          }, function(err, submission) {
+            if (err) return cb(err);
+            submission.assignedTo.mentor.should.eql('a@b.com');
+            submission.assignedTo.expiry.getTime()
+              .should.be.within(Date.now(),
+                                Date.now() + website.ASSIGNMENT_LOCKOUT_MS);
+            cb();
+          });
+        }
+      ], done);
+    });
+
+    it('should disallow self-assigning on conflicts', function(done) {
+      var expTime = Date.now() + 60000;
+      loggedInEmail = "a@b.com";
+      async.series([
+        function(cb) {
+          models.Submission.findOne({
+            _id: 'a07f1f77bcf86cd7994390ff'
+          }, function(err, submission) {
+            if (err) return cb(err);
+            submission.assignTo('blah@b.com', expTime, cb);
+          });
+        },
+        function(cb) {
+          request(app)
+            .post('/submissions/a07f1f77bcf86cd7994390ff')
+            .send({
+              _csrf: 'deadbeef',
+              action: 'assign'
+            })
+            .expect('Location', '/submissions/a07f1f77bcf86cd7994390ff')
+            .expect(303, cb);
+        },
+        function(cb) {
+          models.Submission.findOne({
+            _id: 'a07f1f77bcf86cd7994390ff'
+          }, function(err, submission) {
+            if (err) return cb(err);
+            submission.assignedTo.mentor.should.eql('blah@b.com');
+            submission.assignedTo.expiry.getTime().should.eql(expTime);
+            cb();
+          });
+        }
+      ], done);
+    });
+
+    it('should allow self-unassigning', function(done) {
+      loggedInEmail = "a@b.com";
+      async.series([
+        function(cb) {
+          request(app)
+            .post('/submissions/a07f1f77bcf86cd7994390ff')
+            .send({
+              _csrf: 'deadbeef',
+              action: 'unassign'
+            })
+            .expect('Location', '/submissions/a07f1f77bcf86cd7994390ff')
+            .expect(303, cb);
+        },
+        function(cb) {
+          models.Submission.findOne({
+            _id: 'a07f1f77bcf86cd7994390ff'
+          }, function(err, submission) {
+            if (err) return cb(err);
+            submission.assignedTo.mentor.should.eql('a@b.com');
+            submission.assignedTo.expiry.getTime()
+              .should.be.within(Date.now() - 60000, Date.now());
+            cb();
+          });
+        }
+      ], done);
+    });
+
     it('should work w/ unflagging', function(done) {
       loggedInEmail = "a@b.com";
       async.series([

--- a/views/submission-detail.html
+++ b/views/submission-detail.html
@@ -83,7 +83,8 @@
   </div>
   {% endif %}
 {% else %}
-  {% if submission.getAssignee() == email %}
+  {% set assignee = submission.getAssignee() %}
+  {% if assignee == email %}
   <a name="assess"></a>
   <div class="alert">
     You have until <strong>{{ submission.assignedTo.expiry|timeago }}</strong> to assess this submission. After that point, other mentors will have the opportunity to assess it.
@@ -116,8 +117,8 @@
   <button type="submit" name="action" value="assess" class="btn btn-primary">Submit Assessment</button>
   <button type="submit" name="action" value="unassign" class="btn">Cancel Assessment</button>
   <button type="submit" name="action" value="flag" class="btn"><i class="icon-flag"></i> Report</button>
-  {% elif submission.getAssignee() %}
-  <p>This submission is currently being reviewed by {{ submission.getAssignee() }}.</p>
+  {% elif assignee %}
+  <p>This submission is currently being reviewed by {{ assignee }}.</p>
   {% else %}
   <button type="submit" name="action" value="assign" class="btn btn-large btn-primary">Begin Assessment</button>
   {% endif %}

--- a/views/submission-detail.html
+++ b/views/submission-detail.html
@@ -83,6 +83,11 @@
   </div>
   {% endif %}
 {% else %}
+  {% if submission.getAssignee() == email %}
+  <a name="assess"></a>
+  <div class="alert">
+    You have until <strong>{{ submission.assignedTo.expiry|timeago }}</strong> to assess this submission. After that point, other mentors will have the opportunity to assess it.
+  </div>
   <h2>Rubric</h2>
   {% for rubitem in submission.rubric.items %}
     <label class="checkbox">
@@ -109,7 +114,13 @@
     <textarea class="input-block-level" name="response"></textarea>
   {% endif %}
   <button type="submit" name="action" value="assess" class="btn btn-primary">Submit Assessment</button>
+  <button type="submit" name="action" value="unassign" class="btn">Cancel Assessment</button>
   <button type="submit" name="action" value="flag" class="btn"><i class="icon-flag"></i> Report</button>
+  {% elif submission.getAssignee() %}
+  <p>This submission is currently being reviewed by {{ submission.getAssignee() }}.</p>
+  {% else %}
+  <button type="submit" name="action" value="assign" class="btn btn-large btn-primary">Begin Assessment</button>
+  {% endif %}
 {% endif %}
 </form>
 {% endblock %}


### PR DESCRIPTION
Now when users view a submission they can assess, they see this:

![screen shot 2013-06-17 at 4 31 47 pm](https://f.cloud.github.com/assets/124687/664774/39b753fe-d78d-11e2-94c8-54d51ce021fc.png)

When they click the "Begin Assessment" button, they see this:

![screen shot 2013-06-17 at 4 32 18 pm](https://f.cloud.github.com/assets/124687/664783/52192b0c-d78d-11e2-9d65-10e8153e4822.png)

For the next 15 minutes, anyone else who has permission to view the submission sees this:

![screen shot 2013-06-17 at 4 32 02 pm](https://f.cloud.github.com/assets/124687/664791/6f246112-d78d-11e2-970a-d8a2bf97207e.png)

Once the 15 minute window expires, anyone who views the submission will see the "Begin Assessment" button again. The original assignee may also click the "Cancel Assessment" button on the review form to release themselves from the assignment early, if they wish.

This fixes #69.
