### PR TITLE
Provide live thumbs up/down icon on submit assessment button w/ tooltip.

### DIFF
--- a/static/js/submission-detail.js
+++ b/static/js/submission-detail.js
@@ -1,0 +1,19 @@
+$(window).ready(function() {
+  var requiredRubricItems = $('input[name^="rubric_"][data-required]');
+  var assessBtn = $('#js-assess');
+  var isAccepted = function() {
+    for (var i = 0; i < requiredRubricItems.length; i++)
+      if (!requiredRubricItems[i].checked) return false;
+    return true;
+  };
+
+  assessBtn.tooltip({
+    title: function() {
+      return $(this).data(isAccepted() ? "accept-tooltip" : "reject-tooltip");
+    }
+  });
+  requiredRubricItems.change(function() {
+    $("i", assessBtn).attr("class", "icon-thumbs-" +
+                                    (isAccepted() ? "up" : "down"));
+  }).trigger("change");
+});

--- a/views/submission-detail.html
+++ b/views/submission-detail.html
@@ -90,9 +90,11 @@
     You have until <strong>{{ submission.assignedTo.expiry|timeago }}</strong> to assess this submission. After that point, other mentors will have the opportunity to assess it.
   </div>
   <h2>Rubric</h2>
+  <p>All required items must be checked for the learner to be awarded.</p>
   {% for rubitem in submission.rubric.items %}
     <label class="checkbox">
-      <input type="checkbox" name="rubric_{{loop.index0}}"> 
+      <input type="checkbox" name="rubric_{{loop.index0}}"
+             {% if rubitem.required %}data-required{% endif %}>
       {% if rubitem.required %}
       <strong>{{ rubitem.text }} (required)</strong>
       {% else %}
@@ -114,7 +116,7 @@
      feel free to add them.</p>
     <textarea class="input-block-level" name="response"></textarea>
   {% endif %}
-  <button type="submit" name="action" value="assess" class="btn btn-primary">Submit Assessment</button>
+  <button id="js-assess" type="submit" name="action" value="assess" class="btn" data-accept-tooltip="All required rubric items are satisfied, so the learner will be awarded." data-reject-tooltip="Not all required rubric items are satisfied, so the submission will be rejected."><i></i> Submit Assessment</button>
   <button type="submit" name="action" value="unassign" class="btn">Cancel Assessment</button>
   <button type="submit" name="action" value="flag" class="btn"><i class="icon-flag"></i> Report</button>
   {% elif assignee %}
@@ -124,4 +126,8 @@
   {% endif %}
 {% endif %}
 </form>
+{% endblock %}
+
+{% block scripts %}
+<script src="/js/submission-detail.js"></script>
 {% endblock %}


### PR DESCRIPTION
This is intended to help resolve the problem of mentors accidentally rejecting submissions they intend to accept and vice versa, as mentioned in #75 and #76.

A modal yes/no dialog as suggested in #76 isn't ideal because users will most likely habituate to always confirming the action, thereby [accidentally confirming it](http://alistapart.com/article/neveruseawarning) the one time they'd want to reject it. So instead, I added some JS that provides a live indication of whether the submission will be accepted or rejected based on what the mentor has filled out so far.

If not all the required rubric items are checked, a thumbs-down icon will appear on the "submit assessment" button; when the user hovers over the button, a tooltip will appear like so:

![screen shot 2013-06-27 at 1 57 23 pm](https://f.cloud.github.com/assets/124687/717766/3ea810a6-df53-11e2-8376-5b071780f2e3.png)

If all required items are checked, however, a thumbs-up icon will appear with the following hover tooltip:

![screen shot 2013-06-27 at 1 57 38 pm](https://f.cloud.github.com/assets/124687/717771/538763fa-df53-11e2-8a13-ba0ff70dd256.png)

If folks are still making the mistake this solution is intended to resolve, we should either implement the modal confirmation mentioned in #76 (which is easy to implement, yet inhumane) or the undo/revise functionality mentioned in #75 (which is hard to implement, yet humane).

**Implementation note:** I didn't add unit tests to submission-detail.js right now since the code is written in a way that it's ok if it throws exceptions (the functionality isn't critical to the functioning of the site), and it's also kind of hard to test regardless.
